### PR TITLE
removed title attribute and added domutils

### DIFF
--- a/packages/launcher/src/widget.tsx
+++ b/packages/launcher/src/widget.tsx
@@ -174,7 +174,6 @@ export class Launcher extends VDomRenderer<ILauncher.IModel> {
                 icon={icon}
                 iconClass={classes(iconClass, 'jp-Icon-cover')}
                 stylesheet="launcherSection"
-                title={cat + ' Icon'}
                 aria-hidden={true}
               />
               <h2 className="jp-Launcher-sectionTitle" title={cat + ' Title'}>

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
+import { DOMUtils } from './domutils'; 
 import { UUID } from '@lumino/coreutils';
 import { Signal } from '@lumino/signaling';
 import { ElementAttrs, VirtualElement, VirtualNode } from '@lumino/virtualdom';
@@ -833,7 +834,7 @@ namespace Private {
 
     /// TODO set better unique id for title
     if (titleNodes.length) {
-      titleNodes[0].textContent = title;
+      titleNodes[0].id = DOMUtils.createDomID();
       if (!titleNodes[0].id) {
         titleNodes[0].id = performance.now().toString();
       }


### PR DESCRIPTION
As per comments on PR (#14320), removed redundant title attribute in code and left aria-hidden.

Changed the getTitleSvg function to include DOMUtils as per recommendation

tested via speak aloud and narrator. Previously was reading out icons descriptions but is no longer doing so in either.
 Created new PR as unable to push into previous PR due to base branch changes. 

Reference PR: https://github.com/jupyterlab/jupyterlab/pull/14320


## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->


## User-facing changes

Icons ignored by screenreader 
## Backwards-incompatible changes

NA
